### PR TITLE
🐛 fix(docs): fix ReadTheDocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,4 +5,4 @@ build:
   commands:
     - curl -LsSf https://astral.sh/uv/install.sh | sh
     - ~/.local/bin/uv tool install tox --with tox-uv -p 3.14 --managed-python
-    - ~/.local/bin/tox run -e docs --
+    - ~/.local/bin/tox run -e docs -- "$READTHEDOCS_OUTPUT/html"

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -2,7 +2,7 @@ How it works
 ============
 
 Where does python-discovery look?
--------------------------------
+---------------------------------
 
 When you call :func:`~python_discovery.get_interpreter`, the library checks several locations in
 order. It stops as soon as it finds an interpreter that matches your spec.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 python-discovery
-============
+================
 
 You may have multiple Python versions installed on your machine -- system Python, versions from
 `pyenv <https://github.com/pyenv/pyenv>`_, `mise <https://mise.jdx.dev/>`_,


### PR DESCRIPTION
The ReadTheDocs build was failing because the tox invocation ended with a bare `--`, which set posargs to empty and caused `sphinx-build` to receive no output directory argument. 🔧

The fix passes `$READTHEDOCS_OUTPUT/html` as posargs so sphinx-build writes directly to the path RTD expects. Two RST title underlines in `docs/index.rst` and `docs/explanation.rst` were also too short, tripping the `-W` (warnings as errors) flag.