### PR TITLE
✨ feat(discovery): add `predicate` parameter to `get_interpreter`

### DIFF
--- a/src/python_discovery/__init__.py
+++ b/src/python_discovery/__init__.py
@@ -8,6 +8,7 @@ from ._cache import ContentStore, DiskCache, PyInfoCache
 from ._discovery import get_interpreter
 from ._py_info import PythonInfo
 from ._py_spec import PythonSpec
+from ._specifier import SimpleSpecifier, SimpleSpecifierSet, SimpleVersion
 
 __version__ = version("python-discovery")
 
@@ -17,6 +18,9 @@ __all__ = [
     "PyInfoCache",
     "PythonInfo",
     "PythonSpec",
+    "SimpleSpecifier",
+    "SimpleSpecifierSet",
+    "SimpleVersion",
     "__version__",
     "get_interpreter",
 ]

--- a/src/python_discovery/_cache.py
+++ b/src/python_discovery/_cache.py
@@ -19,25 +19,47 @@ _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 class ContentStore(Protocol):
     """A store for reading and writing cached content."""
 
-    def exists(self) -> bool: ...
+    def exists(self) -> bool:
+        """Return whether the cached content exists."""
+        ...
 
-    def read(self) -> dict | None: ...
+    def read(self) -> dict | None:
+        """Read the cached content, or ``None`` if unavailable or corrupt."""
+        ...
 
-    def write(self, content: dict) -> None: ...
+    def write(self, content: dict) -> None:
+        """
+        Persist *content* to the store.
 
-    def remove(self) -> None: ...
+        :param content: interpreter metadata to cache.
+        """
+        ...
+
+    def remove(self) -> None:
+        """Delete the cached content."""
+        ...
 
     @contextmanager
-    def locked(self) -> Generator[None]: ...
+    def locked(self) -> Generator[None]:
+        """Context manager that acquires an exclusive lock on this store."""
+        ...
 
 
 @runtime_checkable
 class PyInfoCache(Protocol):
     """Cache interface for Python interpreter information."""
 
-    def py_info(self, path: Path) -> ContentStore: ...
+    def py_info(self, path: Path) -> ContentStore:
+        """
+        Return the content store for the interpreter at *path*.
 
-    def py_info_clear(self) -> None: ...
+        :param path: absolute path to a Python executable.
+        """
+        ...
+
+    def py_info_clear(self) -> None:
+        """Remove all cached interpreter information."""
+        ...
 
 
 class DiskContentStore:
@@ -101,10 +123,16 @@ class DiskCache:
         return self._root / "py_info" / "4"
 
     def py_info(self, path: Path) -> DiskContentStore:
+        """
+        Return the content store for the interpreter at *path*.
+
+        :param path: absolute path to a Python executable.
+        """
         key = sha256(str(path).encode("utf-8")).hexdigest()
         return DiskContentStore(self._py_info_dir, key)
 
     def py_info_clear(self) -> None:
+        """Remove all cached interpreter information."""
         folder = self._py_info_dir
         if folder.exists():
             for entry in folder.iterdir():

--- a/src/python_discovery/_py_info.py
+++ b/src/python_discovery/_py_info.py
@@ -483,9 +483,11 @@ class PythonInfo:  # noqa: PLR0904
         return cls._current_system
 
     def to_json(self) -> str:
+        """Serialize this interpreter information to a JSON string."""
         return json.dumps(self.to_dict(), indent=2)
 
     def to_dict(self) -> dict[str, object]:
+        """Convert this interpreter information to a plain dictionary."""
         data = {var: (getattr(self, var) if var != "_creators" else None) for var in vars(self)}
         version_info = data["version_info"]
         data["version_info"] = version_info._asdict() if hasattr(version_info, "_asdict") else version_info
@@ -520,11 +522,21 @@ class PythonInfo:  # noqa: PLR0904
 
     @classmethod
     def from_json(cls, payload: str) -> PythonInfo:
+        """
+        Deserialize interpreter information from a JSON string.
+
+        :param payload: JSON produced by :meth:`to_json`.
+        """
         raw = json.loads(payload)
         return cls.from_dict(raw.copy())
 
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> PythonInfo:
+        """
+        Reconstruct a :class:`PythonInfo` from a plain dictionary.
+
+        :param data: dictionary produced by :meth:`to_dict`.
+        """
         data["version_info"] = VersionInfo(**data["version_info"])  # restore this to a named tuple structure
         result = cls()
         result.__dict__ = data.copy()
@@ -532,6 +544,12 @@ class PythonInfo:  # noqa: PLR0904
 
     @classmethod
     def resolve_to_system(cls, cache: PyInfoCache | None, target: PythonInfo) -> PythonInfo:
+        """
+        Walk virtualenv/venv prefix chains to find the underlying system interpreter.
+
+        :param cache: interpreter metadata cache; when ``None`` results are not cached.
+        :param target: the interpreter to resolve.
+        """
         start_executable = target.executable
         prefixes = OrderedDict()
         while target.system_executable is None:

--- a/src/python_discovery/_py_spec.py
+++ b/src/python_discovery/_py_spec.py
@@ -153,6 +153,7 @@ class PythonSpec:
 
     @property
     def is_abs(self) -> bool:
+        """``True`` if the spec refers to an absolute filesystem path."""
         return self.path is not None and pathlib.Path(self.path).is_absolute()
 
     def _check_version_specifier(self, spec: PythonSpec) -> bool:

--- a/src/python_discovery/_specifier.py
+++ b/src/python_discovery/_specifier.py
@@ -52,6 +52,11 @@ class SimpleVersion:
 
     @classmethod
     def from_string(cls, version_str: str) -> SimpleVersion:
+        """
+        Parse a PEP 440 version string (e.g. ``3.12.1``).
+
+        :param version_str: the version string to parse.
+        """
         stripped = version_str.strip()
         if not (match := _VERSION_RE.match(stripped)):
             msg = f"Invalid version: {version_str}"
@@ -123,6 +128,11 @@ class SimpleSpecifier:
 
     @classmethod
     def from_string(cls, spec_str: str) -> SimpleSpecifier:
+        """
+        Parse a single PEP 440 specifier (e.g. ``>=3.10``).
+
+        :param spec_str: the specifier string to parse.
+        """
         stripped = spec_str.strip()
         if not (match := _SPECIFIER_RE.match(stripped)):
             msg = f"Invalid specifier: {spec_str}"
@@ -148,7 +158,11 @@ class SimpleSpecifier:
         )
 
     def contains(self, version_str: str) -> bool:
-        """Check if a version string satisfies this specifier."""
+        """
+        Check if a version string satisfies this specifier.
+
+        :param version_str: the version string to test.
+        """
         try:
             candidate = SimpleVersion.from_string(version_str) if isinstance(version_str, str) else version_str
         except ValueError:
@@ -223,6 +237,11 @@ class SimpleSpecifierSet:
 
     @classmethod
     def from_string(cls, specifiers_str: str = "") -> SimpleSpecifierSet:
+        """
+        Parse a comma-separated PEP 440 specifier string (e.g. ``>=3.10,<4``).
+
+        :param specifiers_str: the specifier string to parse.
+        """
         stripped = specifiers_str.strip()
         specs: list[SimpleSpecifier] = []
         if stripped:
@@ -234,7 +253,11 @@ class SimpleSpecifierSet:
         return cls(specifiers_str=stripped, specifiers=tuple(specs))
 
     def contains(self, version_str: str) -> bool:
-        """Check if a version satisfies all specifiers in the set."""
+        """
+        Check if a version satisfies all specifiers in the set.
+
+        :param version_str: the version string to test.
+        """
         if not self.specifiers:
             return True
         return all(spec.contains(version_str) for spec in self.specifiers)


### PR DESCRIPTION
Hatch monkeypatches `propose_interpreters` to filter out incompatible interpreters, which broke when virtualenv moved discovery into this package. There's currently no public API for downstream tools to reject interpreters that match a spec but fail some external constraint (e.g. platform compatibility). ✨ This adds a `predicate` callback to `get_interpreter` so tools like Hatch can filter without monkeypatching internals.

The `predicate` is evaluated after an interpreter satisfies the spec, giving callers a clean hook to accept or reject candidates while the discovery loop continues searching on rejection. Named `predicate` instead of `filter` to avoid shadowing the Python builtin (ruff `A002` rule). The parameter defaults to `None`, so existing callers are unaffected.

📝 Sphinx docstrings were added to all public API methods and properties across `ContentStore`, `PyInfoCache`, `DiskCache`, `PythonInfo`, `PythonSpec`, and `SimpleSpecifierSet`. `SimpleSpecifierSet` is now also exported from the top-level package for downstream use.

Closes #30