### PR TITLE
🐛 fix(test): add i686 to known ISAs

### DIFF
--- a/tests/py_info/test_py_info.py
+++ b/tests/py_info/test_py_info.py
@@ -338,7 +338,7 @@ def test_py_info_machine_property() -> None:
     assert machine is not None
     assert isinstance(machine, str)
     assert len(machine) > 0
-    known_isas = {"arm64", "x86_64", "x86", "ppc64le", "ppc64", "s390x", "riscv64"}
+    known_isas = {"arm64", "i686", "ppc64", "ppc64le", "riscv64", "s390x", "x86", "x86_64"}
     assert machine in known_isas, f"unexpected machine value: {machine}"
 
 


### PR DESCRIPTION
The `test_py_info_machine_property` test fails on i686 platforms because that architecture string wasn't included in the `known_isas` set. While `x86` was already listed, `i686` is the value returned by `platform.machine()` on 32-bit x86 Linux systems and is a distinct, valid identifier.

Adding `i686` to the set ensures the test passes on all platforms where the package is expected to work. The set entries are also sorted alphabetically for readability.

Fixes #41