### PR TITLE
🐛 fix(discovery): match prerelease versions against major.minor specs

### DIFF
--- a/src/python_discovery/_py_info.py
+++ b/src/python_discovery/_py_info.py
@@ -469,12 +469,24 @@ class PythonInfo:  # noqa: PLR0904
         if spec.version_specifier is None:  # pragma: no cover
             return True
         version_info = self.version_info
-        release = f"{version_info.major}.{version_info.minor}.{version_info.micro}"
-        if version_info.releaselevel != "final":
-            suffix = {"alpha": "a", "beta": "b", "candidate": "rc"}.get(version_info.releaselevel)
-            if suffix is not None:  # pragma: no branch # releaselevel is always alpha/beta/candidate here
+        for specifier in spec.version_specifier:
+            assert specifier.version is not None  # noqa: S101
+            numeric_version = specifier.version_str
+            for prefix in ("rc", "b", "a"):
+                if prefix in numeric_version:
+                    numeric_version = numeric_version.split(prefix)[0]
+                    break
+            precision = numeric_version.count(".") + 1
+            release = ".".join(str(c) for c in [version_info.major, version_info.minor, version_info.micro][:precision])
+            if (
+                version_info.releaselevel != "final"
+                and (precision == 3 or specifier.version.pre_type is not None)  # noqa: PLR2004
+                and (suffix := {"alpha": "a", "beta": "b", "candidate": "rc"}.get(version_info.releaselevel))
+            ):
                 release = f"{release}{suffix}{version_info.serial}"
-        return spec.version_specifier.contains(release)
+            if not specifier.contains(release):
+                return False
+        return True
 
     _current_system = None
     _current = None

--- a/tests/test_py_info_extra.py
+++ b/tests/test_py_info_extra.py
@@ -276,25 +276,29 @@ def test_satisfies_version_specifier_fails() -> None:
     assert CURRENT.satisfies(spec, impl_must_match=False) is False
 
 
-def test_satisfies_prerelease_version() -> None:
+@pytest.mark.parametrize(
+    ("version_info", "spec_str", "expected"),
+    [
+        pytest.param(VersionInfo(3, 14, 0, "alpha", 1), ">=3.14.0a1", True, id="alpha_match_exact"),
+        pytest.param(VersionInfo(3, 14, 0, "beta", 1), ">=3.14.0b1", True, id="beta_match_exact"),
+        pytest.param(VersionInfo(3, 14, 0, "candidate", 1), ">=3.14.0rc1", True, id="rc_match_exact"),
+        pytest.param(VersionInfo(3, 15, 0, "alpha", 6), ">=3.15", True, id="prerelease_match_major_minor"),
+        pytest.param(VersionInfo(3, 15, 0, "alpha", 6), ">=3.15.0", False, id="prerelease_not_match_full_precision"),
+        pytest.param(VersionInfo(3, 15, 0, "alpha", 5), "<3.15.0a6", True, id="earlier_prerelease_less_than"),
+        pytest.param(VersionInfo(3, 15, 0, "alpha", 6), "<3.15.0a6", False, id="prerelease_not_less_than_itself"),
+        pytest.param(VersionInfo(3, 15, 0, "alpha", 6), ">=3.15.0a6", True, id="prerelease_match_itself"),
+        pytest.param(VersionInfo(3, 15, 0, "alpha", 6), ">=3.15.0a7", False, id="prerelease_not_match_later"),
+        pytest.param(VersionInfo(3, 15, 0, "final", 0), ">=3.15.0a6", True, id="final_greater_than_prerelease"),
+        pytest.param(VersionInfo(3, 15, 0, "final", 0), "<3.15.0a6", False, id="final_not_less_than_prerelease"),
+        pytest.param(VersionInfo(3, 15, 0, "final", 0), ">=3.15", True, id="final_match_major_minor"),
+        pytest.param(VersionInfo(3, 15, 1, "alpha", 1), ">=3.15.0", True, id="later_micro_prerelease_match"),
+    ],
+)
+def test_satisfies_version_specifier_prerelease(version_info: VersionInfo, spec_str: str, expected: bool) -> None:
     info = copy.deepcopy(CURRENT)
-    info.version_info = VersionInfo(3, 14, 0, "alpha", 1)
-    spec = PythonSpec.from_string_spec(">=3.14.0a1")
-    assert info.satisfies(spec, impl_must_match=False) is True
-
-
-def test_satisfies_prerelease_beta() -> None:
-    info = copy.deepcopy(CURRENT)
-    info.version_info = VersionInfo(3, 14, 0, "beta", 1)
-    spec = PythonSpec.from_string_spec(">=3.14.0b1")
-    assert info.satisfies(spec, impl_must_match=False) is True
-
-
-def test_satisfies_prerelease_candidate() -> None:
-    info = copy.deepcopy(CURRENT)
-    info.version_info = VersionInfo(3, 14, 0, "candidate", 1)
-    spec = PythonSpec.from_string_spec(">=3.14.0rc1")
-    assert info.satisfies(spec, impl_must_match=False) is True
+    info.version_info = version_info
+    spec = PythonSpec.from_string_spec(spec_str)
+    assert info.satisfies(spec, impl_must_match=False) is expected
 
 
 def test_satisfies_path_not_abs_basename_match() -> None:


### PR DESCRIPTION
Testing Python prereleases became broken when libraries tried to specify version requirements using major.minor notation like `>=3.15`. For example, building against Python 3.15.0a6 in Fedora would fail to match `>=3.15` even though 3.15.0a6 is logically part of the 3.15 series. 🐛 This affected any environment testing against alpha, beta, or release candidate Python versions.

The root issue was comparing full version strings without accounting for precision. When checking `>=3.15` against `3.15.0a6`, the code was comparing the complete version including prerelease suffix against a normalized final version. Since PEP 440 defines prereleases as strictly less than final releases, this comparison always failed.

The fix determines precision by counting dots in the specifier's version string, then constructs the comparison version accordingly. ✨ For `>=3.15` (two components), we compare `3.15` without the prerelease suffix. For `>=3.15.0` (three components), we include the prerelease suffix `3.15.0a6`, which correctly fails since prereleases are less than finals. For `>=3.15.0a1` (explicit prerelease), we include the suffix and compare prereleases properly.

This preserves PEP 440 semantics for full-precision specifiers while fixing the broken behavior for major.minor specifiers commonly used in real-world testing scenarios.