### PR TITLE
🐛 fix(subprocess): drain pipes after killing timed-out process

### DIFF
--- a/src/python_discovery/_cached_py_info.py
+++ b/src/python_discovery/_cached_py_info.py
@@ -210,6 +210,7 @@ def _run_subprocess(
             code = process.returncode
         except TimeoutExpired:
             process.kill()
+            process.communicate()
             out, err, code = "", "timed out", -1
         except OSError as os_error:
             out, err, code = "", os_error.strerror, os_error.errno

--- a/tests/test_cached_py_info.py
+++ b/tests/test_cached_py_info.py
@@ -113,13 +113,14 @@ def test_run_subprocess_with_cookies(mocker: MockerFixture) -> None:
 
 def test_run_subprocess_timeout(mocker: MockerFixture) -> None:
     mock_process = MagicMock()
-    mock_process.communicate.side_effect = TimeoutExpired(cmd="python", timeout=30)
+    mock_process.communicate.side_effect = [TimeoutExpired(cmd="python", timeout=30), ("", "")]
     mocker.patch("python_discovery._cached_py_info.Popen", return_value=mock_process)
     failure, result = _run_subprocess(PythonInfo, sys.executable, dict(os.environ))
     assert failure is not None
     assert "timed out" in str(failure)
     assert result is None
     mock_process.kill.assert_called_once()
+    assert mock_process.communicate.call_count == 2
 
 
 def test_run_subprocess_nonzero_exit(mocker: MockerFixture) -> None:


### PR DESCRIPTION
The 5s timeout added in #42 correctly kills hung interpreter probes, but on Windows the caller still hangs. 🪟 `process.kill()` terminates the process but doesn't close inherited pipe handles — the reader threads spawned by the initial `communicate(timeout=5)` stay blocked on `fh.read()` indefinitely. This was confirmed in tox CI where the timeout fired, the process was killed, yet the test still hung with `_readerthread` stuck on pipe reads.

Adding `process.communicate()` after `process.kill()` joins the reader threads and drains any remaining pipe data, as [documented in the Python subprocess docs](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.kill). This is a one-line fix that completes the timeout handling introduced in 1.1.1.