### PR TITLE
🐛 fix(test): add loongarch64 to known ISAs

### DIFF
--- a/tests/py_info/test_py_info.py
+++ b/tests/py_info/test_py_info.py
@@ -338,7 +338,7 @@ def test_py_info_machine_property() -> None:
     assert machine is not None
     assert isinstance(machine, str)
     assert len(machine) > 0
-    known_isas = {"arm64", "i686", "ppc64", "ppc64le", "riscv64", "s390x", "x86", "x86_64"}
+    known_isas = {"arm64", "i686", "loongarch64", "ppc64", "ppc64le", "riscv64", "s390x", "x86", "x86_64"}
     assert machine in known_isas, f"unexpected machine value: {machine}"
 
 


### PR DESCRIPTION
This makes tests green on my loongarch64 machine. The exact error is:


```
    def test_py_info_machine_property() -> None:
        machine = CURRENT.machine
        assert machine is not None
        assert isinstance(machine, str)
        assert len(machine) > 0
        known_isas = {"arm64", "i686", "ppc64", "ppc64le", "riscv64", "s390x", "x86", "x86_64"}
>       assert machine in known_isas, f"unexpected machine value: {machine}"
E       AssertionError: unexpected machine value: loongarch64
E       assert 'loongarch64' in {'arm64', 'i686', 'ppc64', 'ppc64le', 'riscv64', 's390x', ...}

tests/py_info/test_py_info.py:342: AssertionError
```