### PR TITLE
🐛 fix(spec): allow dots in machine/ISA specifier

### DIFF
--- a/src/python_discovery/_py_spec.py
+++ b/src/python_discovery/_py_spec.py
@@ -17,7 +17,7 @@ PATTERN = re.compile(
     (?P<version>[0-9.]+)?           # version (e.g. 3.12, 3.12.1)
     (?P<threaded>t)?                # free-threaded flag
     (?:-(?P<arch>32|64))?           # architecture bitness
-    (?:-(?P<machine>[a-zA-Z0-9_]+))?  # ISA (e.g. arm64, x86_64)
+    (?:-(?P<machine>[a-zA-Z0-9_.]+))?  # ISA (e.g. arm64, x86_64, i86pc.64bit)
     $
     """,
     re.VERBOSE,

--- a/tests/test_py_spec.py
+++ b/tests/test_py_spec.py
@@ -180,6 +180,7 @@ def test_specifier_satisfies_with_partial_information() -> None:
         pytest.param("cpython3.12-64", None, id="no-machine"),
         pytest.param("cpython3.12", None, id="no-arch-no-machine"),
         pytest.param("python3.12-64-arm64", "arm64", id="python-impl"),
+        pytest.param("cpython3.14-64-i86pc.64bit", "i86pc.64bit", id="dotted-machine"),
     ],
 )
 def test_spec_parse_machine(spec_str: str, expected_machine: str | None) -> None:


### PR DESCRIPTION
On OpenIndiana, `platform.machine()` returns `i86pc.64bit`, which contains a dot. The spec parser regex for the machine group only accepted `[a-zA-Z0-9_]`, so any spec string built from such a machine value failed to parse. This caused `test_py_info_satisfies_with_machine` to fail on that platform.

🔧 Adding `.` to the character class in the `machine` capture group fixes parsing for dotted machine identifiers while remaining backward-compatible with all existing values like `arm64`, `x86_64`, and `ppc64le`.

Fixes #75