### PR TITLE
🐛 fix: resolve executable-only symlinks in system_executable

### DIFF
--- a/docs/changelog/84.bugfix.rst
+++ b/docs/changelog/84.bugfix.rst
@@ -1,0 +1,3 @@
+Resolve executable-only symlinks when computing ``system_executable``, mirroring CPython's ``getpath.realpath``
+(python/cpython#115237): a symlink to the interpreter binary now resolves to the real interpreter, while a fully
+symlinked interpreter tree is kept as-is - by :user:`gaborbernat`.

--- a/src/python_discovery/_py_info.py
+++ b/src/python_discovery/_py_info.py
@@ -244,7 +244,7 @@ class PythonInfo:  # noqa: PLR0904
             candidate = link if os.path.isabs(link) else os.path.normpath(os.path.join(os.path.dirname(result), link))
             # normpath through a symlinked directory may point at a different file - stop resolving there
             if not (os.path.exists(candidate) and os.path.samefile(real_path, candidate)):
-                break
+                return result
             result = candidate
         return result
 

--- a/src/python_discovery/_py_info.py
+++ b/src/python_discovery/_py_info.py
@@ -204,7 +204,7 @@ class PythonInfo:  # noqa: PLR0904
         # if we're not in a virtual environment, this is already a system python, so return the original executable
         # note we must choose the original and not the pure executable as shim scripts might throw us off
         if not (self.real_prefix or (self.base_prefix is not None and self.base_prefix != self.prefix)):
-            return self.original_executable
+            return self._resolve_executable_symlink(self.original_executable)
 
         # if this is NOT a virtual environment, can't determine easily, bail out
         if self.real_prefix is not None:
@@ -220,10 +220,33 @@ class PythonInfo:  # noqa: PLR0904
 
         # We're not in a venv and base_executable exists; use it directly
         if os.path.exists(base_executable):  # pragma: >=3.11 cover
-            return base_executable
+            return self._resolve_executable_symlink(base_executable)
 
         # Try fallback for POSIX virtual environments
         return self._try_posix_fallback_executable(base_executable)  # pragma: >=3.11 cover
+
+    def _resolve_executable_symlink(self, path: str) -> str:
+        """
+        Resolve symlinks of the executable itself, but never of its parent directories.
+
+        Mirrors CPython's ``getpath.realpath`` (and ``venv`` in python/cpython#115237): an executable-only symlink
+        resolves to the real interpreter so its home can be located, while a fully symlinked interpreter tree is
+        kept as-is.
+        """
+        result = os.path.abspath(path)
+        if self.os != "posix":  # CPython only does this where HAVE_READLINK
+            return result
+        real_path = os.path.realpath(result)
+        if not os.path.exists(real_path):  # symlink loop or broken symlink
+            return result
+        while os.path.islink(result):
+            link = os.readlink(result)
+            candidate = link if os.path.isabs(link) else os.path.normpath(os.path.join(os.path.dirname(result), link))
+            # normpath through a symlinked directory may point at a different file - stop resolving there
+            if not (os.path.exists(candidate) and os.path.samefile(real_path, candidate)):
+                break
+            result = candidate
+        return result
 
     def _try_posix_fallback_executable(self, base_executable: str) -> str | None:
         """Find a versioned Python binary as fallback for POSIX virtual environments."""

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -431,16 +431,15 @@ def test_predicate_none_is_noop(session_cache: DiskCache) -> None:
 def test_predicate_with_fallback_specs(session_cache: DiskCache) -> None:
     current = PythonInfo.current_system(session_cache)
     major, minor = current.version_info.major, current.version_info.minor
-    accepted_exe: str | None = None
+    proposed: list[str] = []
 
     def reject_first(info: PythonInfo) -> bool:
-        nonlocal accepted_exe
-        if accepted_exe is None:
-            accepted_exe = str(info.executable)
-            return False
-        return True
+        proposed.append(str(info.executable))
+        return len(proposed) > 1
 
     result = get_interpreter([f"{major}.{minor}", sys.executable], [], session_cache, predicate=reject_first)
-    assert accepted_exe is not None
+    # rejecting the first proposal must not abort discovery; a later proposal (same or fallback spec) is accepted -
+    # on hosts where every alias resolves to one interpreter the fallback re-proposes it, so executables may match
     assert result is not None
-    assert str(result.executable) != accepted_exe
+    assert len(proposed) > 1
+    assert str(result.executable) == proposed[-1]

--- a/tests/test_py_info_extra.py
+++ b/tests/test_py_info_extra.py
@@ -19,6 +19,8 @@ except ImportError:  # pragma: no cover
     tk = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
 
 CURRENT = PythonInfo.current_system()
@@ -71,7 +73,9 @@ def test_fast_get_system_executable_not_venv() -> None:
     info = PythonInfo()
     info.real_prefix = None
     info.base_prefix = info.prefix
-    assert info._fast_get_system_executable() == info.original_executable
+    result = info._fast_get_system_executable()
+    assert result is not None
+    assert Path(result).samefile(info.original_executable)
 
 
 def test_fast_get_system_executable_real_prefix() -> None:
@@ -94,6 +98,105 @@ def test_fast_get_system_executable_same_as_current(mocker: MockerFixture) -> No
     info.base_prefix = "/different/prefix"
     mocker.patch.object(sys, "_base_executable", sys.executable, create=True)
     assert info._fast_get_system_executable() is None
+
+
+@pytest.fixture
+def posix_info() -> PythonInfo:
+    info = PythonInfo()
+    info.os = "posix"
+    return info
+
+
+def test_resolve_executable_symlink_not_posix() -> None:
+    info = PythonInfo()
+    info.os = "nt"
+    assert info._resolve_executable_symlink("/some/python") == str(Path("/some/python").resolve())
+
+
+def _layout_regular_file(tmp_path: Path) -> tuple[Path, Path]:
+    exe = tmp_path / "python"
+    exe.touch()
+    return exe, exe
+
+
+def _layout_broken_symlink(tmp_path: Path) -> tuple[Path, Path]:
+    link = tmp_path / "python"
+    link.symlink_to(tmp_path / "missing")
+    return link, link
+
+
+def _layout_absolute_symlink(tmp_path: Path) -> tuple[Path, Path]:
+    exe = tmp_path / "install" / "bin" / "python3.12"
+    exe.parent.mkdir(parents=True)
+    exe.touch()
+    link = tmp_path / "symdir" / "python3"
+    link.parent.mkdir()
+    link.symlink_to(exe)
+    return link, exe
+
+
+def _layout_relative_chain(tmp_path: Path) -> tuple[Path, Path]:
+    exe = tmp_path / "python3.12"
+    exe.touch()
+    (tmp_path / "python3").symlink_to("python3.12")
+    link = tmp_path / "python"
+    link.symlink_to("python3")
+    return link, exe
+
+
+def _layout_tree_symlink(tmp_path: Path) -> tuple[Path, Path]:
+    real_bin = tmp_path / "install" / "bin"
+    real_bin.mkdir(parents=True)
+    (real_bin / "python3").touch()
+    tree_link = tmp_path / "tree"
+    tree_link.symlink_to(tmp_path / "install")
+    via_tree = tree_link / "bin" / "python3"
+    return via_tree, via_tree
+
+
+def _layout_normpath_mismatch(tmp_path: Path) -> tuple[Path, Path]:
+    real_dir = tmp_path / "deep" / "real"
+    real_dir.mkdir(parents=True)
+    (tmp_path / "deep" / "exe").touch()
+    (real_dir / "python").symlink_to("../exe")
+    dir_link = tmp_path / "link"
+    dir_link.symlink_to(real_dir)
+    via_link = dir_link / "python"
+    return via_link, via_link
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX only")
+@pytest.mark.parametrize(
+    "layout",
+    [
+        pytest.param(_layout_regular_file, id="regular-file"),
+        pytest.param(_layout_broken_symlink, id="broken-symlink"),
+        pytest.param(_layout_absolute_symlink, id="absolute-symlink"),
+        pytest.param(_layout_relative_chain, id="relative-chain"),
+        pytest.param(_layout_tree_symlink, id="tree-preserved"),
+        pytest.param(_layout_normpath_mismatch, id="normpath-mismatch"),
+    ],
+)
+def test_resolve_executable_symlink(
+    tmp_path: Path,
+    posix_info: PythonInfo,
+    layout: Callable[[Path], tuple[Path, Path]],
+) -> None:
+    path, expected = layout(tmp_path)
+    assert posix_info._resolve_executable_symlink(str(path)) == str(expected)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX only")
+def test_from_exe_resolves_executable_only_symlink(tmp_path: Path, session_cache: DiskCache) -> None:
+    system_exe = CURRENT.system_executable
+    assert system_exe is not None
+    link = tmp_path / "python3"
+    link.symlink_to(system_exe)
+    info = PythonInfo.from_exe(str(link), session_cache, ignore_cache=True)
+    assert info is not None
+    assert info.system_executable is not None
+    assert Path(info.system_executable).samefile(system_exe)
+    assert not Path(info.system_executable).is_symlink()
 
 
 def test_try_posix_fallback_not_posix() -> None:


### PR DESCRIPTION
Creating a virtual environment through a symlink that points at just the interpreter binary left `PythonInfo.system_executable` set to the unresolved symlink. virtualenv derives the `home` and `base-executable` keys of `pyvenv.cfg` from this value, so the symlink directory got recorded as the interpreter home even though it contains no `lib/`. 🐛 Layouts where `home` must locate the base interpreter's stdlib, such as python-build-standalone, end up with a broken environment (pypa/virtualenv#3157).

The fix ports the `getpath.realpath` semantics that CPython's `venv` adopts in python/cpython#115237: only the symlink chain of the final path component gets followed, one `readlink` hop at a time, and every hop must `samefile` the fully resolved path so that a `normpath` across a symlinked directory stops the walk. A symlink to the binary alone now resolves to the real interpreter, while a fully symlinked interpreter tree keeps its symlinked `home`. The walk runs on POSIX only, matching CPython's `HAVE_READLINK` gate, and applies to both the non-venv `original_executable` branch and the venv `sys._base_executable` branch of `_fast_get_system_executable`.

Cached interpreter records refresh on upgrade because the cache stores the `_py_info.py` content hash. The companion virtualenv PR pypa/virtualenv#3166 bumps the dependency floor and its app-data `py_info` cache key. Fixes #84.
