### PR TITLE
Use hatchling<1.28 for Python versions < 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,6 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = [
-  "hatch-vcs>=0.5",
-  "hatchling>=1.28; python_version >= '3.10'",
-  "hatchling<1.28; python_version < '3.10'"
-]
+requires = [ "hatch-vcs>=0.5", "hatchling>=1.28; python_version>='3.10'", "hatchling<1.28; python_version<'3.10'" ]
 
 [project]
 name = "python-discovery"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 build-backend = "hatchling.build"
 requires = [
   "hatch-vcs>=0.5",
-  "hatchling>=1.28",
+  "hatchling>=1.28; python_version >= '3.10'",
+  "hatchling<1.28; python_version < '3.10'"
 ]
 
 [project]


### PR DESCRIPTION
Hi @gaborbernat,

Since in my IBM team we're required to do source package builds inside a RHEL 9.x, we're currently bound to Python 3.9. When trying to build `virtualenv>=21`, I ran into issues since `python-discovery` as a dependency restricts source builds to Python 3.10 onwards due to its `hatchling` version requirements:

```bash
Collecting python-discovery==1.4.2
  Using cached python_discovery-1.4.2.tar.gz (70 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'error'
  error: subprocess-exited-with-error
  
  × pip subprocess to install build dependencies did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Collecting hatch-vcs>=0.5
        Using cached hatch_vcs-0.5.0-py3-none-any.whl
      ERROR: Ignored the following yanked versions: 1.4.0, 1.19.1, 1.22.0, 1.22.1, 1.26.0, 1.26.1, 1.26.2
      ERROR: Ignored the following versions that require a different python version: 1.28.0 Requires-Python >=3.10; 1.29.0 Requires-Python >=3.10; 1.30.0 Requires-Python >=3.10; 1.30.1 Requires-Python >=3.10
      ERROR: Could not find a version that satisfies the requirement hatchling>=1.28
```

<br/>

I re-run the build allowing hatchling versions prior to 1.28 for Python versions <3.10 and it was going well:

```bash
$ python3 -m build --verbose python_discovery-1.4.2/
* Creating isolated environment: virtualenv+pip...
* Installing packages in isolated environment:
  - hatch-vcs>=0.5
  - hatchling<1.28; python_version < '3.10'
  - hatchling>=1.28; python_version >= '3.10'
 < Using cached hatchling-1.27.0-py3-none-any.whl (75 kB)
* Building wheel...
Successfully built python_discovery-1.4.2.tar.gz and python_discovery-1.4.2-py3-none-any.whl
```
<br/>

So this change would allow us to migrate to more recent `virtualenv` versions while preserving the build requirements for more modern Python versions. Would you be willing to integrate that? 

Thx for all your work around virtualenv, it's a crucial component for my team and me at IBM.
