### PR TITLE
🐛 fix(build): match hatchling floor to python-requires

### DIFF
--- a/docs/changelog/92.packaging.rst
+++ b/docs/changelog/92.packaging.rst
@@ -1,0 +1,3 @@
+Constrain the ``hatchling`` build requirement per Python version so sdist builds resolve a compatible backend on the
+declared ``>=3.8`` floor - ``hatchling>=1.28`` dropped Python 3.9, leaving 3.8/3.9 unbuildable from source - by
+:user:`gaborbernat`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 build-backend = "hatchling.build"
 requires = [
   "hatch-vcs>=0.5",
-  "hatchling>=1.28",
+  "hatchling>=1.27; python_version<'3.10'",
+  "hatchling>=1.28; python_version>='3.10'",
 ]
 
 [project]


### PR DESCRIPTION
Installing python-discovery from source on Python 3.8 or 3.9 fails at the build step with `No matching distribution found for hatchling>=1.28`, reported in #92. The build pin `hatchling>=1.28` requires Python `>=3.10`, yet the project declares `requires-python = ">=3.8"` and tests against 3.8/3.9, so pip cannot find a backend when it builds the sdist on those interpreters.

Nothing needs that specific floor; it landed during the standalone rewrite in #28. An environment marker splits the requirement so interpreters below 3.10 pull `hatchling>=1.27`, the last release supporting `<3.10`, while 3.10 and newer keep `hatchling>=1.28`.

Published wheels ship prebuilt and skip the backend, so they stay unchanged. This restores source builds on the older interpreters the package already supports.
