### PR TITLE
📦 build: move dev extras to PEP 735 dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,21 +46,6 @@ dependencies = [
   "filelock>=3.15.4",
   "platformdirs<5,>=4.3.6",
 ]
-optional-dependencies.docs = [
-  "furo>=2025.12.19",
-  "sphinx>=9.1",
-  "sphinx-autodoc-typehints>=3.6.3",
-  "sphinxcontrib-mermaid>=2",
-  "sphinxcontrib-towncrier>=0.4",
-  "towncrier>=25.8",
-]
-optional-dependencies.testing = [
-  "covdefaults>=2.3",
-  "coverage>=7.5.4",
-  "pytest>=8.3.5",
-  "pytest-mock>=3.14",
-  "setuptools>=75.1",
-]
 urls.Changelog = "https://github.com/tox-dev/python-discovery/releases"
 urls.Documentation = "https://python-discovery.readthedocs.io"
 urls.Homepage = "https://github.com/tox-dev/python-discovery"
@@ -68,11 +53,26 @@ urls.Source = "https://github.com/tox-dev/python-discovery"
 urls.Tracker = "https://github.com/tox-dev/python-discovery/issues"
 
 [dependency-groups]
+docs = [
+  "furo>=2025.12.19",
+  "sphinx>=9.1",
+  "sphinx-autodoc-typehints>=3.6.3",
+  "sphinxcontrib-mermaid>=2",
+  "sphinxcontrib-towncrier>=0.4",
+  "towncrier>=25.8",
+]
 release = [
   "gitpython>=3.1.46",
   "packaging>=26",
   "pre-commit>=4.5.1",
   "towncrier>=25.8",
+]
+test = [
+  "covdefaults>=2.3",
+  "coverage>=7.5.4",
+  "pytest>=8.3.5",
+  "pytest-mock>=3.14",
+  "setuptools>=75.1",
 ]
 
 [tool.hatch]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,13 @@ urls.Source = "https://github.com/tox-dev/python-discovery"
 urls.Tracker = "https://github.com/tox-dev/python-discovery/issues"
 
 [dependency-groups]
+test = [
+  "covdefaults>=2.3",
+  "coverage>=7.5.4",
+  "pytest>=8.3.5",
+  "pytest-mock>=3.14",
+  "setuptools>=75.1",
+]
 docs = [
   "furo>=2025.12.19",
   "sphinx>=9.1",
@@ -66,13 +73,6 @@ release = [
   "packaging>=26",
   "pre-commit>=4.5.1",
   "towncrier>=25.8",
-]
-test = [
-  "covdefaults>=2.3",
-  "coverage>=7.5.4",
-  "pytest>=8.3.5",
-  "pytest-mock>=3.14",
-  "setuptools>=75.1",
 ]
 
 [tool.hatch]

--- a/tox.toml
+++ b/tox.toml
@@ -6,7 +6,7 @@ skip_missing_interpreters = true
 description = "run the tests with pytest"
 package = "wheel"
 wheel_build_env = ".pkg"
-extras = ["testing"]
+dependency_groups = ["test"]
 pass_env = ["DIFF_AGAINST", "PYTEST_*"]
 set_env.COVERAGE_FILE = "{work_dir}{/}.coverage.{env_name}"
 commands = [
@@ -46,7 +46,7 @@ commands = [["ty", "check", "--output-format", "concise", "--error-on-warning", 
 
 [env.docs]
 description = "build documentation"
-extras = ["docs"]
+dependency_groups = ["docs"]
 commands = [
   [
     "sphinx-build",
@@ -81,5 +81,5 @@ commands = [["python", "{tox_root}/tasks/release.py", "--version", "{posargs}"]]
 [env.dev]
 description = "generate a DEV environment"
 package = "editable"
-extras = ["testing"]
+dependency_groups = ["test"]
 commands = [["uv", "pip", "tree"], ["python", "-c", "import sys; print(sys.executable)"]]


### PR DESCRIPTION
The `docs` and `testing` extras serve only development, yet as `[project.optional-dependencies]` they ship in the published wheel metadata and let anyone `pip install python-discovery[testing]`. PEP 735 `[dependency-groups]` fits dev-only sets better, since a group stays local to the source tree and never publishes. 📦

This moves both extras into the existing `[dependency-groups]` table, with `testing` becoming `test` and `docs` keeping its name, and drops the now-empty `optional-dependencies`. The tox environments that pulled these extras (`env_run_base`, `docs`, and `dev`) now reference the groups through `dependency_groups` instead of `extras`.

The `testing` extra is gone; use the `test` group. No consumer-facing install extras remain, so `python-discovery[docs]` and `python-discovery[testing]` no longer resolve.
