### PR TITLE
🐛 fix(uv): match uv's interpreter store lookup

### DIFF
--- a/docs/changelog/109.bugfix.rst
+++ b/docs/changelog/109.bugfix.rst
@@ -1,0 +1,6 @@
+Locate uv's managed interpreter store the way uv itself does, instead of via ``platformdirs``. uv follows the XDG
+convention on every non-Windows platform, so on macOS the store lives in ``~/.local/share/uv/python`` rather than
+``~/Library/Application Support/uv/python``, and on Windows it lives in roaming ``%APPDATA%\uv\python`` rather than
+local ``%LOCALAPPDATA%\uv\uv\python``. Discovery now searches both the current and the legacy directory, and reads
+the uv variables from the ``env`` mapping passed to ``get_interpreter``/``iter_interpreters`` rather than from
+``os.environ`` - by :user:`gaborbernat`.

--- a/docs/changelog/109.packaging.rst
+++ b/docs/changelog/109.packaging.rst
@@ -1,0 +1,2 @@
+Drop the ``platformdirs`` runtime dependency; it was only used to locate uv's interpreter store, which is now
+derived from uv's own rules - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -68,9 +68,33 @@ detects these shims and resolves them to the actual binary.
 How uv-managed Pythons are discovered
 ---------------------------------------
 
-`uv <https://docs.astral.sh/uv/>`_ installs Python interpreters under a single root directory (configurable via
-``UV_PYTHON_INSTALL_DIR``, otherwise defaulting under ``XDG_DATA_HOME`` or the platform user-data path). Each
-install lives in its own subdirectory, but the actual binary location varies by OS and implementation:
+`uv <https://docs.astral.sh/uv/>`_ installs Python interpreters under a single root directory. ``UV_PYTHON_INSTALL_DIR``
+overrides it; otherwise the store is the ``python`` bucket of uv's state directory, which uv derives as follows:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * - Platform
+     - Legacy state directory
+     - Current state directory
+   * - Windows
+     - ``%APPDATA%\uv\data``
+     - ``%APPDATA%\uv`` (roaming, not local)
+   * - macOS
+     - ``~/Library/Application Support/uv``
+     - ``$XDG_DATA_HOME/uv`` or ``~/.local/share/uv``
+   * - Other
+     - same as current
+     - ``$XDG_DATA_HOME/uv`` or ``~/.local/share/uv``
+
+uv follows the XDG convention on macOS too, and falls back to the legacy directory only when that directory already
+exists. python-discovery searches both, in the same order, so a leftover legacy directory cannot hide the store uv
+installs into. A relative ``XDG_DATA_HOME`` does not count, as the XDG specification requires, and Windows ignores it
+outright. Every one of these variables comes from the ``env`` mapping passed to
+:func:`~python_discovery.get_interpreter`, never from the process environment.
+
+Each install lives in its own subdirectory, but the actual binary location varies by OS and implementation:
 
 .. list-table::
    :header-rows: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dynamic = [
 ]
 dependencies = [
   "filelock>=3.15.4",
-  "platformdirs<5,>=4.3.6",
 ]
 urls.Changelog = "https://github.com/tox-dev/python-discovery/releases"
 urls.Documentation = "https://python-discovery.readthedocs.io"

--- a/src/python_discovery/_discovery.py
+++ b/src/python_discovery/_discovery.py
@@ -7,8 +7,6 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
-from platformdirs import user_data_path
-
 from ._compat import fs_path_id
 from ._py_info import PythonInfo
 from ._py_spec import PythonSpec
@@ -267,25 +265,46 @@ def _propose_from_uv(
     *,
     all_implementations: bool = False,
 ) -> Generator[tuple[PythonInfo | None, bool], None, None]:
-    if uv_python_dir := os.getenv("UV_PYTHON_INSTALL_DIR"):
-        uv_python_path = Path(uv_python_dir).expanduser()
-    elif xdg_data_home := os.getenv("XDG_DATA_HOME"):
-        uv_python_path = Path(xdg_data_home).expanduser() / "uv" / "python"
-    else:
-        uv_python_path = user_data_path("uv") / "python"
-
     patterns: list[str] = ["*/bin/python", "*/python.exe"]
     if all_implementations:
         patterns.extend(("*/bin/pypy*", "*/bin/graalpy", "*/pypy*.exe", "*/bin/graalpy.exe"))
     seen_uv_paths: set[str] = set()
-    for pattern in patterns:
-        for exe_path in uv_python_path.glob(pattern):
-            resolved = str(Path(exe_path).resolve())
-            if resolved in seen_uv_paths:
-                continue
-            seen_uv_paths.add(resolved)
-            if interpreter := PathPythonInfo.from_exe(str(exe_path), cache, raise_on_error=False, env=env):
-                yield interpreter, True
+    for root in _uv_python_roots(env):
+        for pattern in patterns:
+            for exe_path in root.glob(pattern):
+                resolved = str(Path(exe_path).resolve())
+                if resolved in seen_uv_paths:
+                    continue
+                seen_uv_paths.add(resolved)
+                if interpreter := PathPythonInfo.from_exe(str(exe_path), cache, raise_on_error=False, env=env):
+                    yield interpreter, True
+
+
+def _uv_python_roots(env: Mapping[str, str]) -> Generator[Path, None, None]:
+    """Yield uv's store roots, legacy first; searching both keeps a stale legacy directory from hiding the live one."""
+    if install_dir := env.get("UV_PYTHON_INSTALL_DIR"):
+        yield Path(install_dir).expanduser()
+        return
+    for state_dir in _uv_state_dirs(env):
+        yield state_dir / "python"
+
+
+def _uv_state_dirs(env: Mapping[str, str]) -> Generator[Path, None, None]:
+    """Yield uv's legacy state directory then its current one, the order uv prefers them in."""
+    windows = sys.platform == "win32"
+    home = Path(env.get("USERPROFILE" if windows else "HOME") or "~").expanduser()
+    if windows:
+        app_data = Path(env["APPDATA"]) if "APPDATA" in env else home / "AppData" / "Roaming"
+        yield app_data / "uv" / "data"
+        yield app_data / "uv"
+        return
+    if sys.platform == "darwin":
+        yield home / "Library" / "Application Support" / "uv"
+    # uv ignores a relative XDG_DATA_HOME, as the XDG specification requires
+    if (xdg_data_home := env.get("XDG_DATA_HOME")) and (xdg := Path(xdg_data_home)).is_absolute():
+        yield xdg / "uv"
+    else:
+        yield home / ".local" / "share" / "uv"
 
 
 def get_paths(env: Mapping[str, str]) -> Generator[Path, None, None]:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -91,66 +91,6 @@ def test_relative_path(session_cache: DiskCache, monkeypatch: pytest.MonkeyPatch
     assert result is not None
 
 
-def test_uv_python(
-    monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory, mocker: MockerFixture
-) -> None:
-    monkeypatch.delenv("UV_PYTHON_INSTALL_DIR", raising=False)
-    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
-    monkeypatch.setenv("PATH", "")
-    mocker.patch.object(PythonInfo, "satisfies", return_value=False)
-
-    uv_python_install_dir = tmp_path_factory.mktemp("uv_python_install_dir")
-    with patch("python_discovery._discovery.PathPythonInfo.from_exe") as mock_from_exe, monkeypatch.context() as m:
-        m.setenv("UV_PYTHON_INSTALL_DIR", str(uv_python_install_dir))
-
-        get_interpreter("python", [])
-        mock_from_exe.assert_not_called()
-
-        bin_path = uv_python_install_dir.joinpath("some-py-impl", "bin")
-        bin_path.mkdir(parents=True)
-        bin_path.joinpath("python").touch()
-        get_interpreter("python", [])
-        mock_from_exe.assert_called_once()
-        assert mock_from_exe.call_args[0][0] == str(bin_path / "python")
-
-        mock_from_exe.reset_mock()
-        python_exe = "python.exe" if IS_WIN else "python"
-        dir_in_path = tmp_path_factory.mktemp("path_bin_dir")
-        dir_in_path.joinpath(python_exe).touch()
-        m.setenv("PATH", str(dir_in_path))
-        get_interpreter("python", [])
-        mock_from_exe.assert_called_once()
-        assert mock_from_exe.call_args[0][0] == str(dir_in_path / python_exe)
-
-    xdg_data_home = tmp_path_factory.mktemp("xdg_data_home")
-    with patch("python_discovery._discovery.PathPythonInfo.from_exe") as mock_from_exe, monkeypatch.context() as m:
-        m.setenv("XDG_DATA_HOME", str(xdg_data_home))
-
-        get_interpreter("python", [])
-        mock_from_exe.assert_not_called()
-
-        bin_path = xdg_data_home.joinpath("uv", "python", "some-py-impl", "bin")
-        bin_path.mkdir(parents=True)
-        bin_path.joinpath("python").touch()
-        get_interpreter("python", [])
-        mock_from_exe.assert_called_once()
-        assert mock_from_exe.call_args[0][0] == str(bin_path / "python")
-
-    user_data_path = tmp_path_factory.mktemp("user_data_path")
-    with patch("python_discovery._discovery.PathPythonInfo.from_exe") as mock_from_exe, monkeypatch.context() as m:
-        m.setattr("python_discovery._discovery.user_data_path", lambda x: user_data_path / x)
-
-        get_interpreter("python", [])
-        mock_from_exe.assert_not_called()
-
-        bin_path = user_data_path.joinpath("uv", "python", "some-py-impl", "bin")
-        bin_path.mkdir(parents=True)
-        bin_path.joinpath("python").touch()
-        get_interpreter("python", [])
-        mock_from_exe.assert_called_once()
-        assert mock_from_exe.call_args[0][0] == str(bin_path / "python")
-
-
 def test_discovery_fallback_fail(session_cache: DiskCache, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     result = get_interpreter(["magic-one", "magic-two"], cache=session_cache)

--- a/tests/test_uv_store.py
+++ b/tests/test_uv_store.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+import pytest
+
+from python_discovery import get_interpreter
+from python_discovery._discovery import IS_WIN
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pytest_mock import MockerFixture
+
+# no interpreter answers to this, so discovery walks every source instead of stopping at the running one
+_NO_SUCH_VERSION: Final[str] = "3.99"
+
+
+@pytest.fixture
+def home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """A throwaway home, with every directory variable uv consults pointed into it or unset."""
+    for var in ("UV_PYTHON_INSTALL_DIR", "XDG_DATA_HOME", "APPDATA"):
+        monkeypatch.delenv(var, raising=False)
+    for var in ("HOME", "USERPROFILE"):
+        monkeypatch.setenv(var, str(tmp_path))
+    monkeypatch.setenv("PATH", "")
+    return tmp_path
+
+
+@pytest.fixture
+def plant() -> Callable[[Path], str]:
+    """Create a uv install under a store root and return the executable discovery should reach for."""
+
+    def _plant(root: Path) -> str:
+        (bin_dir := root / "some-py-impl" / "bin").mkdir(parents=True)
+        (executable := bin_dir / "python").touch()
+        return str(executable)
+
+    return _plant
+
+
+@pytest.fixture
+def probed(mocker: MockerFixture) -> Callable[..., list[str]]:
+    """Run a discovery with the interrogation subprocess stubbed out, reporting the executables it reached for."""
+    from_exe = mocker.patch("python_discovery._discovery.PathPythonInfo.from_exe", return_value=None)
+
+    def _probed(**kwargs: object) -> list[str]:
+        get_interpreter(_NO_SUCH_VERSION, [], **kwargs)
+        return [call.args[0] for call in from_exe.call_args_list]
+
+    return _probed
+
+
+@pytest.mark.parametrize("expand_user", [True, False], ids=["expands-user", "absolute"])
+def test_uv_store_install_dir_overrides_the_platform_default(
+    home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    plant: Callable[[Path], str],
+    probed: Callable[..., list[str]],
+    expand_user: bool,
+) -> None:
+    monkeypatch.setenv("UV_PYTHON_INSTALL_DIR", "~/store" if expand_user else str(home / "store"))
+    plant(home / ".local" / "share" / "uv" / "python")
+    executable = plant(home / "store")
+
+    assert probed() == [executable]
+
+
+@pytest.mark.parametrize(
+    ("platform", "extra_env", "expected"),
+    [
+        pytest.param("win32", {"APPDATA": "~/roaming"}, ["~/roaming/uv/data", "~/roaming/uv"], id="windows"),
+        pytest.param("win32", {}, ["~/AppData/Roaming/uv/data", "~/AppData/Roaming/uv"], id="windows-without-appdata"),
+        pytest.param("darwin", {}, ["~/Library/Application Support/uv", "~/.local/share/uv"], id="macos"),
+        pytest.param(
+            "darwin",
+            {"XDG_DATA_HOME": "~/xdg"},
+            ["~/Library/Application Support/uv", "~/xdg/uv"],
+            id="macos-with-xdg",
+        ),
+        pytest.param("linux", {}, ["~/.local/share/uv"], id="linux"),
+        pytest.param("linux", {"XDG_DATA_HOME": "~/xdg"}, ["~/xdg/uv"], id="linux-with-xdg"),
+        pytest.param("linux", {"XDG_DATA_HOME": "relative"}, ["~/.local/share/uv"], id="linux-ignores-relative-xdg"),
+    ],
+)
+@pytest.mark.usefixtures("home")
+def test_uv_store_roots_per_platform(
+    monkeypatch: pytest.MonkeyPatch,
+    plant: Callable[[Path], str],
+    probed: Callable[..., list[str]],
+    platform: str,
+    extra_env: dict[str, str],
+    expected: list[str],
+) -> None:
+    monkeypatch.setattr(sys, "platform", platform)
+    for name, value in extra_env.items():
+        monkeypatch.setenv(name, str(Path(value).expanduser()))
+    executables = [plant(Path(state_dir).expanduser() / "python") for state_dir in expected]
+
+    assert probed() == executables
+
+
+def test_uv_store_windows_ignores_xdg_data_home(
+    home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    plant: Callable[[Path], str],
+    probed: Callable[..., list[str]],
+) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("XDG_DATA_HOME", str(home / "xdg"))
+    plant(home / "xdg" / "uv" / "python")
+    executable = plant(home / "AppData" / "Roaming" / "uv" / "python")
+
+    assert probed() == [executable]
+
+
+def test_uv_store_reads_the_env_argument(
+    home: Path, plant: Callable[[Path], str], probed: Callable[..., list[str]]
+) -> None:
+    executable = plant(home / "store")
+
+    assert probed(env={"PATH": "", "UV_PYTHON_INSTALL_DIR": str(home / "store")}) == [executable]
+
+
+@pytest.mark.usefixtures("home")
+def test_uv_store_missing_root_is_not_an_error(probed: Callable[..., list[str]]) -> None:
+    assert probed() == []
+
+
+def test_uv_store_is_searched_after_path(
+    home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    plant: Callable[[Path], str],
+    probed: Callable[..., list[str]],
+) -> None:
+    store_executable = plant(home / ".local" / "share" / "uv" / "python")
+    (path_dir := home / "path-bin").mkdir()
+    (path_executable := path_dir / f"python{_NO_SUCH_VERSION}{'.exe' if IS_WIN else ''}").touch()
+    monkeypatch.setenv("PATH", str(path_dir))
+
+    assert probed() == [str(path_executable), store_executable]


### PR DESCRIPTION
On macOS the uv store was invisible to discovery, so `get_interpreter("3.8")` returned nothing even with `cpython-3.8.20` installed, and users only reached uv interpreters through the `~/.local/bin` shims that [nox is moving to suppress](https://github.com/wntrblm/nox/issues/1139). 🐛 We fell back to `platformdirs.user_data_path("uv")`, but uv derives its state directory from [etcetera's base strategy](https://github.com/astral-sh/uv/blob/main/crates/uv-dirs/src/lib.rs), which is XDG on every non-Windows platform. Windows was wrong too, in two ways nobody had hit yet: uv writes to roaming `%APPDATA%\uv\python`, while `user_data_path("uv")` defaults `appauthor` to the appname and pointed at local `%LOCALAPPDATA%\uv\uv\python`. Reported in #109.

Discovery now walks the precedence [uv-python's `managed.rs`](https://github.com/astral-sh/uv/blob/main/crates/uv-python/src/managed.rs) and [uv-state](https://github.com/astral-sh/uv/blob/main/crates/uv-state/src/lib.rs) spell out: `UV_PYTHON_INSTALL_DIR` first, then the `python` bucket of uv's legacy and current state directories. uv reaches for the legacy directory only when it already exists and then stops; we search both in that order, so a leftover `~/Library/Application Support/uv` cannot mask the store uv installs into. A relative `XDG_DATA_HOME` no longer counts, matching uv and the XDG specification, and Windows ignores it the way uv does. The `.uv` cwd fallback stays out, since globbing a relative directory for interpreters would surprise callers and it only applies when `$HOME` is unset.

Two things worth a reviewer's attention. These variables now come from the `env` mapping rather than `os.environ`, which the standalone-usage docs already promised, so a caller passing a narrow `env` stops getting uv results it was picking up by accident. 📦 This was also the last use of `platformdirs`, so it leaves the runtime dependency list.
